### PR TITLE
fix: edit area of employee error fixed

### DIFF
--- a/src/app/(pages)/employee/[id]/page.tsx
+++ b/src/app/(pages)/employee/[id]/page.tsx
@@ -206,6 +206,7 @@ const EditEmployeeAndArea = ({ params }: { params: { id: string } }) => {
                     if (areaNameEdited._id === areaOfEmployeeToDelete?._id) {
                         setAreaOfEmployeeToDelete(areaNameEdited)
                     }
+                    setSelectedArea(areaNameEdited)
                     await fetchAllAreas()
                 }
             }


### PR DESCRIPTION
When you changed the name of the employee's area and then edited the employee, it removed him from his area because he kept the name of the previous area.